### PR TITLE
Create NAC server ECR repo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -494,7 +494,8 @@ module "ecr_images" {
     "grafana-image-renderer",
     "cloudwatch-exporter",
     "alpine",
-    "network-access-control-test-certs"
+    "network-access-control-test-certs",
+    "network-access-control-server"
   ]
 }
 


### PR DESCRIPTION
This will hold the Alpine base image used by the Network Access Control
Server.