### PR TITLE
Revert "Allow CodeBuild to read and write Route53 record sets"

### DIFF
--- a/modules/ci-assume-role/main.tf
+++ b/modules/ci-assume-role/main.tf
@@ -125,14 +125,6 @@ data "aws_iam_policy_document" "this" {
 
   statement {
     actions = [
-      "route53:ListResourceRecordSets",
-      "route53:ChangeResourceRecordSets"
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
       "ecs:*"
     ]
     resources = ["*"]


### PR DESCRIPTION
This reverts commit c95209f51c85062649d986b4203a456cb4b8232f.

This change is not required anymore, a better solution was found to
managing environment route53 nameserver records.