### PR TITLE
Remove ECR for NACS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -497,9 +497,6 @@ module "ecr_images" {
     "grafana-image-renderer",
     "cloudwatch-exporter",
     "alpine",
-    "network-access-control-test-certs",
-    "network-access-control-server",
-    "network-access-control-integration-tests",
   ]
 }
 


### PR DESCRIPTION
We pull images straight from Dockerhub now and don't need to manage our
own repos / base images.