### PR TITLE
Allow planning production infrastructure changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -336,6 +336,7 @@ module "network-access-control-server" {
   service_name             = "core"
   docker_image             = "aws/codebuild/standard:5.0"
   manual_production_deploy = true
+  production_plan          = true
 
   name        = "network-access-control-server"
   prefix_name = "${module.label.id}-nac-server"

--- a/modules/ci-pipeline/codepipeline_with_auto_approval.tf
+++ b/modules/ci-pipeline/codepipeline_with_auto_approval.tf
@@ -85,6 +85,28 @@ resource "aws_codepipeline" "codepipeline" {
   }
 
   dynamic "stage" {
+    for_each = var.production_plan ? [1] : []
+
+    content {
+      name = "Production-Plan"
+
+      action {
+        name     = "Plan"
+        owner    = "AWS"
+        category = "Build"
+        provider = "CodeBuild"
+        version  = "1"
+        run_order  = 1
+
+        configuration = {
+          ProjectName = aws_codebuild_project.plan_production.name
+        }
+      }
+    }
+  }
+
+
+  dynamic "stage" {
     for_each = var.manual_production_deploy ? [1] : []
 
     content {
@@ -96,7 +118,7 @@ resource "aws_codepipeline" "codepipeline" {
         category = "Approval"
         provider = "Manual"
         version  = "1"
-        run_order  = 1
+        run_order  = 2
 
         configuration = {
           CustomData = "Deploy to ${aws_codebuild_project.production.name}?"
@@ -115,7 +137,7 @@ resource "aws_codepipeline" "codepipeline" {
       provider        = "CodeBuild"
       input_artifacts = ["source_output"]
       version         = "1"
-      run_order       = 2
+      run_order       = 3
 
       configuration = {
         ProjectName = aws_codebuild_project.production.name

--- a/modules/ci-pipeline/variables.tf
+++ b/modules/ci-pipeline/variables.tf
@@ -56,3 +56,8 @@ variable "manual_production_deploy" {
   type = bool
   default = false
 }
+
+variable "production_plan" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
This combined with the manual deploy step will allow users to see the
Terraform changes planned for production before applying them.

The changes will be outputted in a separate codebuild step, which can be
studied and approved or cancelled.