### PR TITLE
Added CodeStar to staff-infrastructure-network-services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -235,19 +235,16 @@ module "network-access-control-admin" {
   privileged_mode = true
 }
 
-# TODO this pipeline is internal requires Codestar connection debugging.
 module "staff-infrastructure-network-services" {
-  source                   = "./modules/ci-pipeline"
-  service_name             = "core"
-  github_organisation_name = "ministryofjustice"
-  github_repo_name         = "staff-infrastructure-network-services"
-  git_branch_name          = "main"
-
-  name        = "staff-infrastructure-network-services"
-  prefix_name = "${module.label.id}-net-svcs"
-
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnets
+  source                  = "./modules/ci-pipeline-webhook"
+  service_name            = "core"
+  github_repo_id          = "ministryofjustice/staff-infrastructure-network-services"
+  git_branch_name         = "main"
+  name                    = "staff-infrastructure-network-services"
+  prefix_name             = "${module.label.id}-net-svcs"
+  codestar_connection_arn = aws_codestarconnections_connection.nvvs-github-connection.id
+  vpc_id                  = module.vpc.vpc_id
+  subnet_ids              = module.vpc.private_subnets
 
   dev_assume_role_arn            = var.dev_assume_role_arn
   pre_production_assume_role_arn = var.pre_production_assume_role_arn


### PR DESCRIPTION
staff-infrastructure-network-services has codestar connection to replace Github version1 source action.
Tested fine.