### PR TITLE
Applying warning message output

### DIFF
--- a/modules/ci-assume-role/main.tf
+++ b/modules/ci-assume-role/main.tf
@@ -16,7 +16,7 @@ resource "aws_iam_role" "this" {
 }
 EOF
 
-tags = merge(var.tags, {
+  tags = merge(var.tags, {
     Name = "${var.prefix_name}-codebuild-role"
   })
 }

--- a/modules/ci-pipeline-webhook/s3-bucket.tf
+++ b/modules/ci-pipeline-webhook/s3-bucket.tf
@@ -29,9 +29,17 @@ resource "aws_s3_bucket_public_access_block" "artifacts" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "artifacts" {
   depends_on = [
-    aws_s3_bucket_public_access_block.artifacts
+    aws_s3_bucket_public_access_block.artifacts,
+    aws_s3_bucket_ownership_controls.artifacts
   ]
 
   bucket = aws_s3_bucket.artifacts.id
@@ -71,9 +79,17 @@ resource "aws_s3_bucket_public_access_block" "client-tf-state" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "client-tf-state" {
+  bucket = aws_s3_bucket.client-tf-state.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "client-tf-state" {
   depends_on = [
-    aws_s3_bucket_public_access_block.client-tf-state
+    aws_s3_bucket_public_access_block.client-tf-state,
+    aws_s3_bucket_ownership_controls.client-tf-state
   ]
 
   bucket = aws_s3_bucket.client-tf-state.id

--- a/modules/ci-pipeline-webhook/s3-bucket.tf
+++ b/modules/ci-pipeline-webhook/s3-bucket.tf
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_public_access_block" "artifacts" {
 
 resource "aws_s3_bucket_acl" "artifacts" {
   depends_on = [
-	aws_s3_bucket_public_access_block.artifacts
+    aws_s3_bucket_public_access_block.artifacts
   ]
 
   bucket = aws_s3_bucket.artifacts.id
@@ -73,7 +73,7 @@ resource "aws_s3_bucket_public_access_block" "client-tf-state" {
 
 resource "aws_s3_bucket_acl" "client-tf-state" {
   depends_on = [
-	aws_s3_bucket_public_access_block.client-tf-state
+    aws_s3_bucket_public_access_block.client-tf-state
   ]
 
   bucket = aws_s3_bucket.client-tf-state.id

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -64,10 +64,10 @@ resource "aws_s3_bucket_policy" "cloudtrail_bucket" {
   policy = element(data.template_file.s3_bucket_policies.*.rendered, 0)
 }
 
-resource "aws_s3control_bucket_lifecycle_configuration" "cloudtrail_bucket" {
+resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail_bucket" {
   count = local.cloudtrail_log_shipping_to_cloudwatch_count
 
-  bucket = element(aws_s3_bucket.cloudtrail_bucket.*.arn, 0)
+  bucket = element(aws_s3_bucket.cloudtrail_bucket.*.id, 0)
 
   rule {
     id     = "removal"

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -53,24 +53,41 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
 
   bucket        = local.cloud_trail_bucket_name
   force_destroy = true
-  policy        = element(data.template_file.s3_bucket_policies.*.rendered, 0)
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = element(aws_kms_key.cloudtrail_kms_key.*.arn, 0)
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
+  tags = var.tags
+}
 
-  lifecycle_rule {
-    enabled = true
+resource "aws_s3_bucket_policy" "cloudtrail_bucket" {
+  count = local.cloudtrail_log_shipping_to_cloudwatch_count
+
+  bucket = element(aws_s3_bucket.cloudtrail_bucket.*.id, 0)
+  policy = element(data.template_file.s3_bucket_policies.*.rendered, 0)
+}
+
+resource "aws_s3control_bucket_lifecycle_configuration" "cloudtrail_bucket" {
+  count = local.cloudtrail_log_shipping_to_cloudwatch_count
+
+  bucket = element(aws_s3_bucket.cloudtrail_bucket.*.arn, 0)
+
+  rule {
+    id     = "removal"
+    status = "Enabled"
 
     expiration {
       days = 7
     }
   }
+}
 
-  tags = var.tags
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail_bucket" {
+  count = local.cloudtrail_log_shipping_to_cloudwatch_count
+
+  bucket = element(aws_s3_bucket.cloudtrail_bucket.*.id, 0)
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = element(aws_kms_key.cloudtrail_kms_key.*.arn, 0)
+      sse_algorithm     = "aws:kms"
+    }
+  }
 }

--- a/modules/logging_heartbeat/main.tf
+++ b/modules/logging_heartbeat/main.tf
@@ -23,10 +23,10 @@ data "aws_subnets" "default" {
 
 output "debug" {
   value = {
-  vpc_id =data.aws_vpc.default.id
-   aws_subnets = data.aws_subnets.default
-   aws_subnet = data.aws_subnet.default
-   subnet_id = data.aws_subnet.default[0].id
+    vpc_id      = data.aws_vpc.default.id
+    aws_subnets = data.aws_subnets.default
+    aws_subnet  = data.aws_subnet.default
+    subnet_id   = data.aws_subnet.default[0].id
   }
 }
 

--- a/modules/tf-state-mgt/parameter_store.tf
+++ b/modules/tf-state-mgt/parameter_store.tf
@@ -1,7 +1,7 @@
 resource "aws_kms_key" "peramater_store_key" {
   description             = "${var.prefix_name}-${var.service_name}-peramater-store-key"
   deletion_window_in_days = 10
-  
+
   tags = merge(local.tags, {
     Name = "${var.prefix_name}-${var.service_name}"
   })

--- a/modules/tf-state-mgt/s3-bucket.tf
+++ b/modules/tf-state-mgt/s3-bucket.tf
@@ -11,17 +11,24 @@ resource "aws_s3_bucket" "client-tf-state" {
 }
 
 resource "aws_s3_bucket_public_access_block" "client-tf-state" {
-  bucket = aws_s3_bucket.client-tf-state.bucket
+  bucket = aws_s3_bucket.client-tf-state.id
 
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+resource "aws_s3_bucket_ownership_controls" "client-tf-state" {
+  bucket = aws_s3_bucket.client-tf-state.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
 
 resource "aws_s3_bucket_acl" "client-tf-state" {
   depends_on = [
-    aws_s3_bucket_public_access_block.client-tf-state
+    aws_s3_bucket_public_access_block.client-tf-state,
+    aws_s3_bucket_ownership_controls.client-tf-state
   ]
 
   bucket = aws_s3_bucket.client-tf-state.id

--- a/modules/tf-state-mgt/s3-bucket.tf
+++ b/modules/tf-state-mgt/s3-bucket.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "client-tf-state" {
   bucket        = "${var.prefix_name}-client-${var.service_name}-tf-state"
-  acl           = "private"
   force_destroy = false
   lifecycle {
     prevent_destroy = true
@@ -18,6 +17,15 @@ resource "aws_s3_bucket_public_access_block" "client-tf-state" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_acl" "client-tf-state" {
+  depends_on = [
+	aws_s3_bucket_public_access_block.client-tf-state
+  ]
+
+  bucket = aws_s3_bucket.client-tf-state.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "client-tf-state" {

--- a/modules/tf-state-mgt/s3-bucket.tf
+++ b/modules/tf-state-mgt/s3-bucket.tf
@@ -21,7 +21,7 @@ resource "aws_s3_bucket_public_access_block" "client-tf-state" {
 
 resource "aws_s3_bucket_acl" "client-tf-state" {
   depends_on = [
-	aws_s3_bucket_public_access_block.client-tf-state
+    aws_s3_bucket_public_access_block.client-tf-state
   ]
 
   bucket = aws_s3_bucket.client-tf-state.id


### PR DESCRIPTION
These changes are the result of following the warning message output following `terraform plan` operations until all the warning have ceased.

Initially there were 71 warnings.
The S3 bucket configuration is now done in separate Terraform resources.

- aws_s3_bucket_acl
- aws_s3_bucket_server_side_encryption_configuration
- aws_s3_bucket_policy
- aws_s3control_bucket_lifecycle_configuration

These resources have been added where required and the inline attributes or configuration removed.