### PR TITLE
Updating the AWS CodeBuild Docker Image version for

### DIFF
--- a/aws_codepipeline_dns_dhcp.tf
+++ b/aws_codepipeline_dns_dhcp.tf
@@ -50,6 +50,7 @@ module "pttp-infrastructure-ci-pipeline-dhcp-container" {
   pre_production_assume_role_arn = local.pre_production_assume_role_arn
   production_assume_role_arn     = local.production_assume_role_arn
 
+  docker_image    = "aws/codebuild/standard:7.0"
   privileged_mode = true
   tags            = module.label.tags
 }


### PR DESCRIPTION
The CodePipeline named "Staff-Device-DHCP-Server" which manages the "ministryofjustice/staff-device-dhcp-server" repository.

Docker version updated to latest "aws/codebuild/standard:7.0" which uses Ubuntu 22.04 see: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html

This has an up to date version of docker-compose which was required to parse the new config option of "platform". See: https://github.com/ministryofjustice/staff-device-dhcp-server/blob/b7ca25c69db0d76cce11d6db12d2a441493997fe/docker-compose.yml#L33

Jira: ND-120