### PR TITLE
Added docker image 7:0 to logs pipeline modules

### DIFF
--- a/aws_codepipeline_dns_dhcp.tf
+++ b/aws_codepipeline_dns_dhcp.tf
@@ -72,7 +72,7 @@ module "pttp-infrastructure-ci-pipeline-dns-dhcp-admin-container" {
   pre_production_assume_role_arn = local.pre_production_assume_role_arn
   production_assume_role_arn     = local.production_assume_role_arn
 
-  docker_image    = "aws/codebuild/standard:7.0"
+  docker_image    = "aws/codebuild/standard:7.0" 
   privileged_mode = true
   tags            = module.label.tags
 }

--- a/aws_codepipeline_logs.tf
+++ b/aws_codepipeline_logs.tf
@@ -9,6 +9,7 @@ module "pttp-infrastructure-ci-pipeline" {
   vpc_id                   = module.vpc.vpc_id
   subnet_ids               = module.vpc.private_subnets
   manual_production_deploy = true
+  docker_image             = "aws/codebuild/standard:7.0"
 
   dev_assume_role_arn            = local.dev_assume_role_arn
   pre_production_assume_role_arn = local.pre_production_assume_role_arn
@@ -27,6 +28,7 @@ module "staff-device-logging-syslog-to-cloudwatch-pipeline" {
   codestar_connection_arn = aws_codestarconnections_connection.staff-infrastructure-moj.id
   vpc_id                  = module.vpc.vpc_id
   subnet_ids              = module.vpc.private_subnets
+  docker_image            = "aws/codebuild/standard:7.0"
 
   dev_assume_role_arn            = local.dev_assume_role_arn
   pre_production_assume_role_arn = local.pre_production_assume_role_arn


### PR DESCRIPTION
Pinned docker image to standard:7.0 to facilitate platform flag when building containers.