### PR TITLE
Amend CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,5 +137,10 @@ get-secrets: ## Retrieve for inspection the secrets the terraform data lookup re
 s3-audit: ## Write a report on the s3 bucket versioning status for all buckets within this AWS Account.
 	$(DOCKER_RUN) /bin/bash -c "./scripts/s3_versioning_audit.sh"
 
+.PHONY: target
+target: ## terraform apply target
+	$(DOCKER_RUN) terraform apply -target="module.pttp-infrastructure-ci-pipeline-dns-dhcp-admin-container.aws_codepipeline.codepipeline" --auto-approve
+
+
 help:
 	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,5 @@ get-secrets: ## Retrieve for inspection the secrets the terraform data lookup re
 s3-audit: ## Write a report on the s3 bucket versioning status for all buckets within this AWS Account.
 	$(DOCKER_RUN) /bin/bash -c "./scripts/s3_versioning_audit.sh"
 
-.PHONY: target
-target: ## terraform apply target
-	$(DOCKER_RUN) terraform apply -target="module.pttp-infrastructure-ci-pipeline-dns-dhcp-admin-container.aws_codepipeline.codepipeline" --auto-approve
-
-
 help:
 	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/modules/ci-pipeline-webhook/codepipeline_with_auto_approval.tf
+++ b/modules/ci-pipeline-webhook/codepipeline_with_auto_approval.tf
@@ -1,5 +1,6 @@
 resource "aws_codepipeline" "codepipeline" {
   name     = var.name
+  pipeline_type = "V2"
   role_arn = aws_iam_role.codepipeline_role.arn
 
   artifact_store {
@@ -9,6 +10,25 @@ resource "aws_codepipeline" "codepipeline" {
     encryption_key {
       id   = aws_kms_key.artifacts.arn
       type = "KMS"
+    }
+  }
+
+  trigger {
+    provider_type  = "CodeStarSourceConnection"
+    git_configuration {
+      source_action_name = "Source"
+      pull_request {
+        events = ["CLOSED"]
+        branches {
+          includes = ["main"]
+        }
+        file_paths {
+          excludes = ["README.md", 
+                      ".github/*.yml",
+                      ".github/workflows/*.yml", 
+                      "workflows/*.yml"]
+        }
+      } 
     }
   }
 

--- a/modules/ci-pipeline-webhook/codepipeline_with_auto_approval.tf
+++ b/modules/ci-pipeline-webhook/codepipeline_with_auto_approval.tf
@@ -26,7 +26,11 @@ resource "aws_codepipeline" "codepipeline" {
           excludes = ["README.md", 
                       ".github/*.yml",
                       ".github/workflows/*.yml", 
-                      "workflows/*.yml"]
+                      "workflows/*.yml",
+                      "documentation/*.md",
+                      "documentation/diagrams/*.drawio",
+                      "diagrams/*.drawio",
+                      "diagrams/*.png"]
         }
       } 
     }


### PR DESCRIPTION
Added trigger to codebuild to stop pipeline running when changes are made to README or other workflow files.

When PR is merged (closed) the pipeline will trigger. If it contains changes to the below files, the pipeline will not run:

`excludes = ["README.md", 
                      ".github/*.yml",
                      ".github/workflows/*.yml", 
                      "workflows/*.yml"]`