### PR TITLE
added prduction_plan to smtp-relay-server

### DIFF
--- a/aws_codepipeline_smtp.tf
+++ b/aws_codepipeline_smtp.tf
@@ -30,6 +30,7 @@ module "staff-infrastructure-smtp-relay-server" {
   vpc_id                   = module.vpc.vpc_id
   subnet_ids               = module.vpc.private_subnets
   manual_production_deploy = true
+  production_plan          = true
 
   dev_assume_role_arn            = local.dev_assume_role_arn
   pre_production_assume_role_arn = local.pre_production_assume_role_arn


### PR DESCRIPTION
Added production plan to smtp-relay server, given we cannot see what changes are being made to production when the pipeline is run.